### PR TITLE
Submissions download for volunteers

### DIFF
--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -150,6 +150,14 @@ class NemesisBackend(BasicAuthBackend):
 
         return team
 
+    def get_scopes(self, info: NemesisUserInfo) -> List[str]:
+        scopes = ['authenticated']
+
+        if info['is_blueshirt']:
+            scopes.append('blueshirt')
+
+        return scopes
+
     async def validate(self, username: str, password: str) -> ValidationResult:
         if not username:
             raise AuthenticationError("Must provide a username")
@@ -159,8 +167,9 @@ class NemesisBackend(BasicAuthBackend):
         info = await self.load_user(username, password)
 
         team = self.get_team(info)
+        scopes = self.get_scopes(info)
 
-        return ['authenticated'], User(username, team)
+        return scopes, User(username, team)
 
 
 class DummyNemesisBackend(NemesisBackend):

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,15 @@
   <body>
     <div class="container">
       <h1>Virtual Competition Code Submission</h1>
+      {% if 'blueshirt' in request.auth.scopes %}
+      <div class="row">
+        <div class="col-sm-6">
+          <a href="{{ url_for('download_submissions') }}">
+            Download current chosen submissions
+          </a>
+        </div>
+      </div>
+      {% endif %}
       <div class="row">
         {% if request.user.team %}
         <form

--- a/tests/tests_app.py
+++ b/tests/tests_app.py
@@ -276,6 +276,23 @@ class AppTests(test_utils.DatabaseTestCase):
         )
         self.assertEqual([], choices, "Should not have created a choice")
 
+    def test_no_download_link_for_non_blueshirt(self) -> None:
+        download_url = self.url_for('download_submissions')
+
+        response = self.session.get(self.url_for('homepage'))
+
+        html = response.text
+        self.assertNotIn(download_url, html)
+
+    def test_shows_download_link_for_blueshirt(self) -> None:
+        self.session.auth = ('blueshirt', 'blueshirt')
+
+        download_url = self.url_for('download_submissions')
+
+        response = self.session.get(self.url_for('homepage'))
+        html = response.text
+        self.assertIn(download_url, html)
+
     def test_download_submissions_requires_blueshirt(self) -> None:
         response = self.session.get(self.url_for('download_submissions'))
         self.assertEqual(403, response.status_code)

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -74,3 +74,21 @@ class NemesisAuthTests(test_utils.AsyncTestCase):
         self.assertEqual('user', user.username, "Wrong username for user")
 
         self.assertEqual(['authenticated'], scopes, "Wrong scopes for user")
+
+    def test_blueshirt(self) -> None:
+        @self.fake_nemesis.route('/user/user')
+        async def endpoint(request: Request) -> Response:
+            self.info['teams'] = []
+            self.info['is_blueshirt'] = True
+            return JSONResponse(self.info)
+
+        scopes, user = self.await_(self.backend.validate('user', 'pass'))
+
+        self.assertIsNone(user.team, "Wrong team for user")
+        self.assertEqual('user', user.username, "Wrong username for user")
+
+        self.assertEqual(
+            ['authenticated', 'blueshirt'],
+            scopes,
+            "Wrong scopes for user",
+        )


### PR DESCRIPTION
This changes the extract logic to output a single zip rather than a directory of archives, then introduces a new `blueshirt` scope to guard a new view which allows for downloading of that combined zip.

Fixes #12.