### PR TITLE
Add authentication backend based on YAML file

### DIFF
--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -19,6 +19,8 @@ from starlette.authentication import (
 
 logger = logging.getLogger(__name__)
 
+BLUESHIRT_SCOPE = 'blueshirt'
+
 
 class User(SimpleUser):
     def __init__(self, username: str, team: Optional[str]) -> None:
@@ -156,7 +158,7 @@ class NemesisBackend(BasicAuthBackend):
         scopes = ['authenticated']
 
         if info['is_blueshirt']:
-            scopes.append('blueshirt')
+            scopes.append(BLUESHIRT_SCOPE)
 
         return scopes
 
@@ -227,7 +229,7 @@ class FileBackend(BasicAuthBackend):
         scopes = ['authenticated']
 
         if username == self.BLUESHIRT_TEAM:
-            scopes.append('blueshirt')
+            scopes.append(BLUESHIRT_SCOPE)
 
         return scopes
 
@@ -242,6 +244,6 @@ class FileBackend(BasicAuthBackend):
 
         scopes = self.get_scopes(username)
 
-        if 'blueshirt' in scopes:
+        if BLUESHIRT_SCOPE in scopes:
             return scopes, User("SR", None)
         return scopes, User(f"Team {username}", username)

--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -213,6 +213,12 @@ class FileBackend(BasicAuthBackend):
     Credentials are stored in the format `TLA: password`.
 
     Note: Passwords are stored in plaintext.
+    This is acceptable for some use-cases, for example where the
+    data being uploaded is not sensitive or because someone having
+    access to the credentials file almost certainly implies they have
+    access to the upload storage anyway. However this may not be
+    the case for all use-cases and you should evaluate the risks
+    yourself before using this backend. You have been warned!
     """
 
     UNKNOWN_USER_MESSAGE = "Username or password is incorrect"

--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -208,6 +208,8 @@ class FileBackend(BasicAuthBackend):
     Authentication backend which stores credentials in a YAML file.
 
     Credentials are stored in the format `TLA: password`.
+
+    Note: Passwords are stored in plaintext.
     """
 
     UNKNOWN_USER_MESSAGE = "Username or password is incorrect"

--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -2,7 +2,8 @@ import base64
 import logging
 import secrets
 import binascii
-from typing import cast, Dict, List, Tuple, Optional, Sequence
+from typing import cast, Dict, List, Tuple, Union, Optional, Sequence
+from pathlib import Path
 from typing_extensions import TypedDict
 
 import yaml
@@ -217,11 +218,7 @@ class FileBackend(BasicAuthBackend):
     UNKNOWN_USER_MESSAGE = "Username or password is incorrect"
     BLUESHIRT_TEAM = "SRX"
 
-    def __init__(
-        self,
-        *,
-        path: str,
-    ) -> None:
+    def __init__(self, *, path: Union[str, Path]) -> None:
         with open(path) as f:
             self.credentials = cast(Dict[str, str], yaml.safe_load(f))
 

--- a/code_submitter/auth.py
+++ b/code_submitter/auth.py
@@ -5,8 +5,8 @@ import binascii
 from typing import cast, Dict, List, Tuple, Optional, Sequence
 from typing_extensions import TypedDict
 
+import yaml
 import httpx
-from ruamel.yaml import YAML
 from starlette.requests import HTTPConnection
 from starlette.responses import Response
 from starlette.applications import Starlette
@@ -223,7 +223,7 @@ class FileBackend(BasicAuthBackend):
         path: str,
     ) -> None:
         with open(path) as f:
-            self.credentials = cast(Dict[str, str], YAML(typ="safe").load(f))
+            self.credentials = cast(Dict[str, str], yaml.safe_load(f))
 
     def get_scopes(self, username: str) -> List[str]:
         scopes = ['authenticated']

--- a/code_submitter/server.py
+++ b/code_submitter/server.py
@@ -15,7 +15,7 @@ from starlette.datastructures import UploadFile
 from starlette.middleware.authentication import AuthenticationMiddleware
 
 from . import auth, utils, config
-from .auth import User
+from .auth import User, BLUESHIRT_SCOPE
 from .tables import Archive, ChoiceHistory
 
 database = databases.Database(config.DATABASE_URL, force_rollback=config.TESTING)
@@ -53,6 +53,7 @@ async def homepage(request: Request) -> Response:
         'request': request,
         'chosen': chosen,
         'uploads': uploads,
+        'BLUESHIRT_SCOPE': BLUESHIRT_SCOPE,
     })
 
 
@@ -121,7 +122,7 @@ async def upload(request: Request) -> Response:
     )
 
 
-@requires(['authenticated', 'blueshirt'])
+@requires(['authenticated', BLUESHIRT_SCOPE])
 async def download_submissions(request: Request) -> Response:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, mode='w') as zf:

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,4 @@ databases[sqlite]
 sqlalchemy
 alembic
 httpx
-ruamel.yaml
+pyyaml

--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ databases[sqlite]
 sqlalchemy
 alembic
 httpx
+ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,8 @@ markupsafe==1.1.1         # via jinja2, mako
 python-dateutil==2.8.1    # via alembic
 python-editor==1.0.4      # via alembic
 python-multipart==0.0.5   # via -r requirements.in
+pyyaml==5.3.1             # via -r requirements.in
 rfc3986==1.4.0            # via httpx
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via -r requirements.in
 six==1.15.0               # via python-dateutil, python-multipart
 sniffio==1.1.0            # via httpcore, httpx
 sqlalchemy==1.3.18        # via -r requirements.in, alembic, databases

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ python-dateutil==2.8.1    # via alembic
 python-editor==1.0.4      # via alembic
 python-multipart==0.0.5   # via -r requirements.in
 rfc3986==1.4.0            # via httpx
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via -r requirements.in
 six==1.15.0               # via python-dateutil, python-multipart
 sniffio==1.1.0            # via httpcore, httpx
 sqlalchemy==1.3.18        # via -r requirements.in, alembic, databases

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
   <body>
     <div class="container">
       <h1>Virtual Competition Code Submission</h1>
-      {% if 'blueshirt' in request.auth.scopes %}
+      {% if BLUESHIRT_SCOPE in request.auth.scopes %}
       <div class="row">
         <div class="col-sm-6">
           <a href="{{ url_for('download_submissions') }}">

--- a/tests/fixtures/auth-file.yml
+++ b/tests/fixtures/auth-file.yml
@@ -1,0 +1,2 @@
+ABC: password1
+SRX: bees

--- a/tests/tests_app.py
+++ b/tests/tests_app.py
@@ -6,6 +6,7 @@ from unittest import mock
 import test_utils
 from starlette.testclient import TestClient
 
+from code_submitter.auth import BLUESHIRT_SCOPE
 from code_submitter.tables import Archive, ChoiceHistory
 
 
@@ -286,7 +287,7 @@ class AppTests(test_utils.DatabaseTestCase):
         self.assertNotIn(download_url, html)
 
     def test_shows_download_link_for_blueshirt(self) -> None:
-        self.session.auth = ('blueshirt', 'blueshirt')
+        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
 
         download_url = self.url_for('download_submissions')
 
@@ -299,7 +300,7 @@ class AppTests(test_utils.DatabaseTestCase):
         self.assertEqual(403, response.status_code)
 
     def test_download_submissions_when_none(self) -> None:
-        self.session.auth = ('blueshirt', 'blueshirt')
+        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
 
         response = self.session.get(self.url_for('download_submissions'))
         self.assertEqual(200, response.status_code)
@@ -311,7 +312,7 @@ class AppTests(test_utils.DatabaseTestCase):
             )
 
     def test_download_submissions(self) -> None:
-        self.session.auth = ('blueshirt', 'blueshirt')
+        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
 
         self.await_(self.database.execute(
             Archive.insert().values(

--- a/tests/tests_app.py
+++ b/tests/tests_app.py
@@ -287,7 +287,7 @@ class AppTests(test_utils.DatabaseTestCase):
         self.assertNotIn(download_url, html)
 
     def test_shows_download_link_for_blueshirt(self) -> None:
-        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
+        self.session.auth = ('blueshirt', 'blueshirt')
 
         download_url = self.url_for('download_submissions')
 
@@ -300,7 +300,7 @@ class AppTests(test_utils.DatabaseTestCase):
         self.assertEqual(403, response.status_code)
 
     def test_download_submissions_when_none(self) -> None:
-        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
+        self.session.auth = ('blueshirt', 'blueshirt')
 
         response = self.session.get(self.url_for('download_submissions'))
         self.assertEqual(200, response.status_code)
@@ -312,7 +312,7 @@ class AppTests(test_utils.DatabaseTestCase):
             )
 
     def test_download_submissions(self) -> None:
-        self.session.auth = (BLUESHIRT_SCOPE, BLUESHIRT_SCOPE)
+        self.session.auth = ('blueshirt', 'blueshirt')
 
         self.await_(self.database.execute(
             Archive.insert().values(

--- a/tests/tests_app.py
+++ b/tests/tests_app.py
@@ -6,7 +6,6 @@ from unittest import mock
 import test_utils
 from starlette.testclient import TestClient
 
-from code_submitter.auth import BLUESHIRT_SCOPE
 from code_submitter.tables import Archive, ChoiceHistory
 
 

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -106,7 +106,7 @@ class FileAuthTests(test_utils.AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.auth_fixture = Path(__file__).parent / "fixtures/auth-file.yml"
+        self.auth_fixture = Path(__file__).parent / 'fixtures' / 'auth-file.yml'
 
         self.backend = FileBackend(path=str(self.auth_fixture))
 

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -6,7 +6,12 @@ from starlette.responses import Response, JSONResponse
 from starlette.applications import Starlette
 from starlette.authentication import AuthenticationError
 
-from code_submitter.auth import FileBackend, NemesisBackend, NemesisUserInfo
+from code_submitter.auth import (
+    FileBackend,
+    NemesisBackend,
+    BLUESHIRT_SCOPE,
+    NemesisUserInfo,
+)
 
 
 class NemesisAuthTests(test_utils.AsyncTestCase):
@@ -91,7 +96,7 @@ class NemesisAuthTests(test_utils.AsyncTestCase):
         self.assertEqual('user', user.username, "Wrong username for user")
 
         self.assertEqual(
-            ['authenticated', 'blueshirt'],
+            ['authenticated', BLUESHIRT_SCOPE],
             scopes,
             "Wrong scopes for user",
         )
@@ -131,7 +136,7 @@ class FileAuthTests(test_utils.AsyncTestCase):
         self.assertEqual('SR', user.username, "Wrong username for user")
 
         self.assertEqual(
-            ['authenticated', 'blueshirt'],
+            ['authenticated', BLUESHIRT_SCOPE],
             scopes,
             "Wrong scopes for user",
         )

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -106,9 +106,9 @@ class FileAuthTests(test_utils.AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.auth_fixture = Path(__file__).parent / 'fixtures' / 'auth-file.yml'
-
-        self.backend = FileBackend(path=str(self.auth_fixture))
+        self.backend = FileBackend(
+            path=Path(__file__).parent / 'fixtures' / 'auth-file.yml'
+        )
 
     def test_ok(self) -> None:
         scopes, user = self.await_(self.backend.validate('ABC', 'password1'))

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import test_utils
 from starlette.requests import Request
@@ -106,9 +106,9 @@ class FileAuthTests(test_utils.AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        my_dir = os.path.abspath(os.path.dirname(__file__))
+        self.auth_fixture = Path(__file__).parent / "fixtures/auth-file.yml"
 
-        self.backend = FileBackend(path=os.path.join(my_dir, "fixtures", "auth-file.yml"))
+        self.backend = FileBackend(path=str(self.auth_fixture))
 
     def test_ok(self) -> None:
         scopes, user = self.await_(self.backend.validate('ABC', 'password1'))

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -1,9 +1,11 @@
+import os
 import test_utils
 from starlette.requests import Request
-from code_submitter.auth import NemesisBackend, NemesisUserInfo
 from starlette.responses import Response, JSONResponse
 from starlette.applications import Starlette
 from starlette.authentication import AuthenticationError
+
+from code_submitter.auth import FileBackend, NemesisBackend, NemesisUserInfo
 
 
 class NemesisAuthTests(test_utils.AsyncTestCase):
@@ -86,6 +88,46 @@ class NemesisAuthTests(test_utils.AsyncTestCase):
 
         self.assertIsNone(user.team, "Wrong team for user")
         self.assertEqual('user', user.username, "Wrong username for user")
+
+        self.assertEqual(
+            ['authenticated', 'blueshirt'],
+            scopes,
+            "Wrong scopes for user",
+        )
+
+
+class FileAuthTests(test_utils.AsyncTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        my_dir = os.path.abspath(os.path.dirname(__file__))
+
+        self.backend = FileBackend(path=os.path.join(my_dir, "fixtures", "auth-file.yml"))
+
+    def test_ok(self) -> None:
+        scopes, user = self.await_(self.backend.validate('ABC', 'password1'))
+        self.assertEqual(['authenticated'], scopes, "Wrong scopes for user")
+
+        self.assertEqual('Team ABC', user.username, "Wrong username for user")
+        self.assertEqual('ABC', user.team, "Wrong team for user")
+
+    def test_unknown_user(self) -> None:
+        with self.assertRaises(AuthenticationError) as e:
+            self.await_(self.backend.validate('DEF', 'password1'))
+
+        self.assertEqual(e.exception.args[0], FileBackend.UNKNOWN_USER_MESSAGE)
+
+    def test_incorrect_password(self) -> None:
+        with self.assertRaises(AuthenticationError) as e:
+            self.await_(self.backend.validate('ABC', 'password2'))
+
+        self.assertEqual(e.exception.args[0], FileBackend.UNKNOWN_USER_MESSAGE)
+
+    def test_blueshirt(self) -> None:
+        scopes, user = self.await_(self.backend.validate('SRX', 'bees'))
+
+        self.assertIsNone(user.team, "Wrong team for user")
+        self.assertEqual('SR', user.username, "Wrong username for user")
 
         self.assertEqual(
             ['authenticated', 'blueshirt'],

--- a/tests/tests_auth.py
+++ b/tests/tests_auth.py
@@ -107,7 +107,7 @@ class FileAuthTests(test_utils.AsyncTestCase):
         super().setUp()
 
         self.backend = FileBackend(
-            path=Path(__file__).parent / 'fixtures' / 'auth-file.yml'
+            path=Path(__file__).parent / 'fixtures' / 'auth-file.yml',
         )
 
     def test_ok(self) -> None:


### PR DESCRIPTION
This authentication backend is added to allows authentication with a fixed set of credentials for each team.

For blueshirts, the team `SRX` is used.

This file can easily be generated using the [`generate-wifi-keys.py`](https://github.com/srobo/server-puppet/blob/master/scripts/generate-wifi-keys.py) as needed.