### PR TITLE
Add support for downloading previously uploaded archives

### DIFF
--- a/code_submitter/server.py
+++ b/code_submitter/server.py
@@ -138,7 +138,7 @@ async def archive(request: Request) -> Response:
             Archive.c.content,
         ]).where(and_(
             Archive.c.id == archive_id,
-            Archive.c.team == request.user.team,
+            Archive.c.team == user.team,
         )),
     )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,6 +90,7 @@
               <th scope="col">Id</th>
               <th scope="col">Uploaded</th>
               <th scope="col">By</th>
+              <th scope="col">Download</th>
               <th scope="col">Selected</th>
             </tr>
             {% for upload in uploads %}
@@ -99,6 +100,14 @@
               <td>{{ upload.id }}</td>
               <td>{{ upload.created }}</td>
               <td>{{ upload.username }}</td>
+              <td>
+                <a
+                  download
+                  href="{{ url_for('archive', archive_id=upload.id) }}"
+                >
+                  ▼
+                </a>
+              </td>
               <td>
                 {% if upload.id == chosen.archive_id %}
                 <span>★</span>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,6 +45,15 @@ def ensure_database_configured() -> None:
                 'is_student': False,
                 'is_team_leader': False,
             }),
+            NemesisUserInfo({
+                'username': 'no_teams_blueshirt',
+                'first_name': 'No Teams',
+                'last_name': 'Blueshirt',
+                'teams': [],
+                'is_blueshirt': True,
+                'is_student': False,
+                'is_team_leader': False,
+            }),
             *DummyNemesisBackend.DEFAULT,
         ]},
     })


### PR DESCRIPTION
This allows teams a way to better understand which archives are what versions of their code.

Fixes https://github.com/PeterJCLaw/code-submitter/issues/3