### PR TITLE
Improve the error message when a required file is not found

### DIFF
--- a/code_submitter/server.py
+++ b/code_submitter/server.py
@@ -101,7 +101,9 @@ async def upload(request: Request) -> Response:
             zf.getinfo(filepath)
         except KeyError:
             return Response(
-                f"ZIP file must contain a {filepath!r}",
+                f"ZIP file must contain a file named exactly {filepath!r}.\n"
+                "Found the following files:\n " +
+                "\n ".join(zf.namelist()),
                 status_code=400,
             )
 


### PR DESCRIPTION
This is still unfortunately a little obtuse as it is trying to be generic over any possible set of required files, but hopefully is clearer than it was.