### PR TITLE
Add submission count to download buton

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
           <h3>Current Chosen Submissions</h3>
           <p>
             <a download href="{{ url_for('download_submissions') }}">
-              Download ▼
+              Download {{ teams_submissions|length }} submissions ▼
             </a>
           </p>
           <table class="table table-striped">


### PR DESCRIPTION
This makes it easy to see how many submissions there are.

This won't work if there are multiple submission deadlines, but it's a start.